### PR TITLE
Add cmux terminal support

### DIFF
--- a/Astrix/Sources/Utilities/Constants.swift
+++ b/Astrix/Sources/Utilities/Constants.swift
@@ -55,7 +55,8 @@ struct Constants {
             (.warp, "Warp"),
             (.kitty, "Kitty"),
             (.alacritty, "Alacritty"),
-            (.wezTerm, "WezTerm")
+            (.wezTerm, "WezTerm"),
+            (.cmux, "cmux")
         ]
     }
 }
@@ -70,6 +71,7 @@ public enum SupportedApps: String, CaseIterable {
     case kitty = "net.kovidgoyal.kitty"
     case alacritty = "org.alacritty"
     case wezTerm = "com.github.wez.wezterm"
+    case cmux = "com.cmuxterm.app"
     // MARK: - Editors
     case none = "NONE"
     case zed = "dev.zed.Zed"

--- a/Astrix/Sources/Utilities/Scripting.swift
+++ b/Astrix/Sources/Utilities/Scripting.swift
@@ -91,7 +91,7 @@ class Scripting {
         return .none
     }
     public func getFirstInstalledTerminal() -> SupportedApps {
-        let terminals: [SupportedApps] = [.ghostty, .warp, .kitty, .alacritty, .wezTerm, .iTerm, .hyper, .terminal]
+        let terminals: [SupportedApps] = [.ghostty, .warp, .kitty, .alacritty, .wezTerm, .cmux, .iTerm, .hyper, .terminal]
         for terminal in terminals where isAppInstalled(bundleIdentifier: terminal.rawValue) {
             return terminal
         }


### PR DESCRIPTION
## Summary

Closes #11.

- Adds cmux as a supported terminal in the picker (`SupportedTerminalApplications`) and the `SupportedApps` enum.
- Uses the verified bundle ID `com.cmuxterm.app` (the issue's `cmux` was a placeholder; confirmed against both the cmux source repo's Release config and a local `/Applications/cmux.app` install).
- cmux opens via the default `open -b <bundle-id> <path>` command, so no special-case handling is needed.

## Test plan

- [ ] Build the app and Finder extension targets.
- [ ] In the app's terminal picker, confirm "cmux" appears as an option.
- [ ] With cmux installed, select it as the default terminal and use the Finder toolbar button on a folder; verify cmux opens at that folder path.