### PR TITLE
Add Zed Preview editor support

### DIFF
--- a/Astrix/Sources/Utilities/Constants.swift
+++ b/Astrix/Sources/Utilities/Constants.swift
@@ -31,6 +31,7 @@ struct Constants {
         static let SupportedEditorApplications: [(SupportedApps, String)] = [
             (.none, "None"),
             (.zed, "Zed"),
+            (.zedPreview, "Zed Preview"),
             (.xcode, "XCode"),
             (.vsCode, "Visual Studio Code"),
             (.vsCodeInsiders, "Visual Studio Code (Insiders)"),
@@ -73,6 +74,7 @@ public enum SupportedApps: String, CaseIterable {
     // MARK: - Editors
     case none = "NONE"
     case zed = "dev.zed.Zed"
+    case zedPreview = "dev.zed.Zed-Preview"
     case xcode = "com.apple.dt.Xcode"
     case vsCode = "com.microsoft.VSCode"
     case vsCodeInsiders = "com.microsoft.VSCodeInsiders"

--- a/Astrix/Sources/Utilities/Scripting.swift
+++ b/Astrix/Sources/Utilities/Scripting.swift
@@ -84,7 +84,7 @@ class Scripting {
     }
 
     public func getFirstInstalledEditor() -> SupportedApps {
-        let editors: [SupportedApps] = [.cursor, .zed, .vsCodeInsiders, .vsCode, .atom, .sublime4, .sublime3, .intelliJ, .phpStorm, .pyCharm, .rubyMine, .webStorm, .xcode, .androidStudio]
+        let editors: [SupportedApps] = [.cursor, .zedPreview, .zed, .vsCodeInsiders, .vsCode, .atom, .sublime4, .sublime3, .intelliJ, .phpStorm, .pyCharm, .rubyMine, .webStorm, .xcode, .androidStudio]
         for editor in editors where isAppInstalled(bundleIdentifier: editor.rawValue) {
             return editor
         }


### PR DESCRIPTION
## Summary

- Adds Zed Preview as a supported editor in the picker (`SupportedEditorApplications`) and the `SupportedApps` enum, using bundle ID `dev.zed.Zed-Preview`.
- Adds `.zedPreview` to `getFirstInstalledEditor`'s auto-detect list, ahead of stable `.zed` — mirroring the existing `vsCodeInsiders`/`vsCode` ordering so the preview build wins when both are installed.
- Zed Preview opens via the default `open -b <bundle-id> <path>` command, so no special-case handling is needed.

## Test plan

- [ ] Build the app and Finder extension targets.
- [ ] In the editor picker, confirm "Zed Preview" appears as an option.
- [ ] On a machine with only Zed Preview installed, complete onboarding and verify Zed Preview is auto-selected as the default editor.
- [ ] Select Zed Preview as the default editor and use the Finder toolbar button on a folder; verify Zed Preview opens at that folder path.